### PR TITLE
Pinned docker images to stable alpine versions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS node_modules
+FROM node:16.14.0-alpine3.14 AS node_modules
 WORKDIR /app
 COPY package-lock.json package.json ./
 RUN npm install
@@ -7,7 +7,7 @@ COPY . .
 FROM node_modules AS prod_builder
 RUN npm run build
 
-FROM nginx AS prod
+FROM nginx:1.20.2-alpine AS prod
 COPY --from=prod_builder /app/build /usr/share/nginx/html
 
 FROM node_modules AS dev


### PR DESCRIPTION
- Version pinning will ensure all builds will have the same
environment with the same version of Node and Nginx.
- Alpine images are lightweight, secure, and fast.